### PR TITLE
Updating default metadata port

### DIFF
--- a/manifests/agents/l3.pp
+++ b/manifests/agents/l3.pp
@@ -73,7 +73,7 @@ class neutron::agents::l3 (
   $router_id                    = undef,
   $gateway_external_network_id  = undef,
   $handle_internal_only_routers = true,
-  $metadata_port                = '9697',
+  $metadata_port                = '8775',
   $send_arp_for_ha              = '3',
   $periodic_interval            = '40',
   $periodic_fuzzy_delay         = '5',

--- a/spec/classes/neutron_agents_l3_spec.rb
+++ b/spec/classes/neutron_agents_l3_spec.rb
@@ -16,7 +16,7 @@ describe 'neutron::agents::l3' do
       :router_id                    => nil,
       :gateway_external_network_id  => nil,
       :handle_internal_only_routers => true,
-      :metadata_port                => '9697',
+      :metadata_port                => '8775',
       :send_arp_for_ha              => '3',
       :periodic_interval            => '40',
       :periodic_fuzzy_delay         => '5',


### PR DESCRIPTION
The standard metadata port listed within the metadata_agent.ini configuration file specifies port 8775 (manifests/agents/metadata.pp) yet the L3 agent specifies port 9697 (manifests/agents/l3.pp). This leads to inconsistencies where the L3 agent redirects client requests to a port in which the metadata server is _not_ listening. 

REDIRECT   tcp  --  anywhere             169.254.169.254     tcp dpt:http redir ports 9697

This small patch changes the default port that is written out to the configuration for the L3 agent so that it matches the port in which the metadata api is listening on (by default).
