### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -146,7 +146,7 @@ class neutron (
   $auth_strategy               = 'keystone',
   $base_mac                    = 'fa:16:3e:00:00:00',
   $mac_generation_retries      = 16,
-  $dhcp_lease_duration         = 120,
+  $dhcp_lease_duration         = 86400,
   $dhcp_agents_per_network     = 1,
   $allow_bulk                  = true,
   $allow_overlapping_ips       = false,


### PR DESCRIPTION
In Havana - the default lease time was upped to 86400 - 1 day - this should be changed back to the correct default in the puppet module as well.
http://docs.openstack.org/havana/config-reference/content/section_networking-options-reference.html
