### PR TITLE
Split dnsmasq-packages, fixing related issue

### DIFF
--- a/manifests/agents/dhcp.pp
+++ b/manifests/agents/dhcp.pp
@@ -85,8 +85,10 @@ class neutron::agents::dhcp (
 
   case $dhcp_driver {
     /\.Dnsmasq/: {
-      Package[$::neutron::params::dnsmasq_packages] -> Package<| title == 'neutron-dhcp-agent' |>
-      ensure_packages($::neutron::params::dnsmasq_packages)
+      Package[$::neutron::params::dnsmasq-base_package] -> Package<| title == 'neutron-dhcp-agent' |>
+      Package[$::neutron::params::dnsmasq-utils_package] -> Package<| title == 'neutron-dhcp-agent' |>
+      ensure_packages($::neutron::params::dnsmasq-base_package)
+      ensure_packages($::neutron::params::dnsmasq-utils_package)
     }
     default: {
       fail("Unsupported dhcp_driver ${dhcp_driver}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -93,7 +93,8 @@ class neutron::params {
     $metadata_agent_package = 'neutron-metadata-agent'
     $metadata_agent_service = 'neutron-metadata-agent'
 
-    $dnsmasq_packages   = ['dnsmasq-base', 'dnsmasq-utils']
+    $dnsmasq-base_package = ['dnsmasq-base']
+    $dnsmasq-utils_package = ['dnsmasq-utils']
 
     $isc_dhcp_packages  = ['isc-dhcp-server']
 


### PR DESCRIPTION
As a result of this error, 

```
ebug: Executing '/etc/puppet/etckeeper-commit-pre'
debug: catalog supports formats: b64_zlib_yaml dot pson raw yaml; using pson
err: Could not retrieve catalog from remote server: Error 400 on SERVER: Could not find resource 'Package[dnsmasq-base]Package[dnsmasq-utils]' for relationship on 'Package[neutron-dhcp-agent]' on node controller6.ec2.internal
warning: Not using cache on failed catalog
err: Could not retrieve catalog; skipping run
```

I split the $dnsmasq-package in two and resolved the issue I was facing.
