### PR TITLE
stop puppet from breaking neutron

### DIFF
--- a/manifests/agents/ovs.pp
+++ b/manifests/agents/ovs.pp
@@ -144,7 +144,6 @@ class neutron::agents::ovs (
     }
     if $::neutron::params::ovs_cleanup_service {
       service {'ovs-cleanup-service':
-        ensure => $service_ensure,
         name   => $::neutron::params::ovs_cleanup_service,
         enable => $enabled,
       }


### PR DESCRIPTION
The neutron-ovs-cleanup service is meant to run at boot to tear down ovs
interfaces created by Neutron.  The service runs and then exits, which
means that from Puppet's perspective it is always "stopped".

By setting `ensure => started` on the neutron-ovs-cleanup service,
puppet was starting this service every time it runs, which would
completely disable Neutron networking.

This patch removes the `ensure` setting, such that the service will be
enabled and will run at boot but will not be erroneously started by
Puppet.
