### PR TITLE
change inline documentation for neutron_subnet

### DIFF
--- a/lib/puppet/type/neutron_subnet.rb
+++ b/lib/puppet/type/neutron_subnet.rb
@@ -26,7 +26,7 @@ Puppet::Type.newtype(:neutron_subnet) do
   newproperty(:allocation_pools, :array_matching => :all) do
     desc <<-EOT
     Array of Sub-ranges of cidr available for dynamic allocation to ports.
-    Syntax:["start=IPADDR,end=IPADDR", ...]
+    Syntax: {"start" : "172.20.100.10", "end" : "172.20.100.200" }
     EOT
   end
 


### PR DESCRIPTION
the neutron_subnet param for the allocation pool changed from ["start=1.2.3.4,end=1.2.3.5"] to {"start" : "1.2.3.4", "end" : "1.2.3.5" }
