### PR TITLE
add vlan ranges

### DIFF
--- a/manifests/agents/ml2/ovs.pp
+++ b/manifests/agents/ml2/ovs.pp
@@ -83,6 +83,11 @@
 #   (optional) Firewall driver for realizing neutron security group function.
 #   Defaults to 'neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver'.
 #
+# [*network_vlan_ranges*]
+#   (optional) ovs vlan network ranges , List of <physical_network>:<start id>:<end id> eg: physnet1:100:200
+#   if type_drivers is vlan, this options can't empty
+#   Defaults to empty List
+#
 class neutron::agents::ml2::ovs (
   $package_ensure        = 'present',
   $enabled               = true,
@@ -97,7 +102,8 @@ class neutron::agents::ml2::ovs (
   $polling_interval      = 2,
   $l2_population         = false,
   $arp_responder         = false,
-  $firewall_driver       = 'neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver'
+  $firewall_driver       = 'neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver',
+  $network_vlan_ranges   = []
 ) {
 
   include neutron::params
@@ -180,9 +186,11 @@ class neutron::agents::ml2::ovs (
     }
   } else {
     neutron_plugin_ml2 {
+      'agent/tunnel_types': ensure => absent;
       'ovs/enable_tunneling': value  => false;
       'ovs/tunnel_bridge':    ensure => absent;
       'ovs/local_ip':         ensure => absent;
+      'ovs/network_vlan_ranges': value => $network_vlan_ranges;
     }
   }
 


### PR DESCRIPTION
when config ml2 vlan mode, neutron agent can't start.

here is log:

ERROR neutron.plugins.openvswitch.agent.ovs_neutron_agent [-] Tunneling cannot be enabled without a valid local_ip. Agent terminated!

then i track the source code in neutron/plugins/openvswitch/agent/ovs_neutron_agent.py function create_agent_config_map like this:

 # Verify the tunnel_types specified are valid
    for tun in kwargs['tunnel_types']:
        if tun not in constants.TUNNEL_NETWORK_TYPES:
            msg = _('Invalid tunnel type specified: %s'), tun
            raise ValueError(msg)
        if not kwargs['local_ip']:
            msg = _('Tunneling cannot be enabled without a valid local_ip.')
            raise ValueError(msg)

so our puppet script need to remove 'tunnel_types' item， and alse need to add 'network_vlan_ranges'.
