### PR TITLE
Allow uplink provider network type

### DIFF
--- a/lib/puppet/type/neutron_network.rb
+++ b/lib/puppet/type/neutron_network.rb
@@ -42,7 +42,7 @@ Puppet::Type.newtype(:neutron_network) do
 
   newproperty(:provider_network_type) do
     desc 'The physical mechanism by which the virtual network is realized.'
-    newvalues(:flat, :vlan, :local, :gre, :l3_ext, :vxlan)
+    newvalues(:flat, :vlan, :local, :gre, :l3_ext, :vxlan, :uplink)
   end
 
   newproperty(:provider_physical_network) do


### PR DESCRIPTION
At Midonet we are using an additional network type. It is needed because on our setup the edge router is also inside our managed topology