### PR TITLE
Configure metadata agent 'metadata_proxy_shared_secret' as secret

### DIFF
--- a/manifests/agents/metadata.pp
+++ b/manifests/agents/metadata.pp
@@ -102,7 +102,7 @@ class neutron::agents::metadata (
     'DEFAULT/nova_metadata_port':             value => $metadata_port;
     'DEFAULT/nova_metadata_protocol':         value => $metadata_protocol;
     'DEFAULT/nova_metadata_insecure':         value => $metadata_insecure;
-    'DEFAULT/metadata_proxy_shared_secret':   value => $shared_secret;
+    'DEFAULT/metadata_proxy_shared_secret':   value => $shared_secret, secret => true;
     'DEFAULT/metadata_workers':               value => $metadata_workers;
     'DEFAULT/metadata_backlog':               value => $metadata_backlog;
     'DEFAULT/nova_client_cert':               value => $nova_client_cert;


### PR DESCRIPTION
Parameter `DEFAULT/metadata_proxy_shared_secret` of metadata agent should be configured as a secret.